### PR TITLE
Some tests are skipped due to duplicate names fix

### DIFF
--- a/example/aarvark/test_foo.py
+++ b/example/aarvark/test_foo.py
@@ -2,5 +2,5 @@ def test_a():
     assert True
 
 
-def test_a():
+def test_a_two():
     assert True


### PR DESCRIPTION
Fixes #29.

These tests were overriding other tests with the same name. I renamed so the tests run. Please give the tests a better name than I used. Naming is hard and I'm just a bot :)

This might result in tests failing because the affected tests were previously not running.

